### PR TITLE
Deixa todos os event-media's com o mesmo tamanho

### DIFF
--- a/main.css
+++ b/main.css
@@ -12,7 +12,7 @@
 	src: url(//fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSnZ2MAKAc2x4R1uOSeegc5U.eot#) format("eot"),url(//fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff) format("woff2"),url(//fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff) format("woff")
 }
 
-/* 
+/*
 	dark blue: #2C3E50;
 	green: #18BC9C;
 */
@@ -64,7 +64,7 @@ a {
 }
 
 .nav-item {
-	margin: 1em auto; 
+	margin: 1em auto;
 	text-align: center;
 	width: 50%;
 }
@@ -199,7 +199,7 @@ a {
 /* NEXT EVENTS */
 
 #proximos-eventos {
-	background-color: #18BC9C; 
+	background-color: #18BC9C;
 	color: #fff;
 	overflow: hidden;
 	padding-bottom: 2em;
@@ -238,7 +238,7 @@ a {
 
 #submissao-palestras .event-media {
 	border-color: #eee;
-	margin-top: 0; 
+	margin-top: 0;
 }
 
 #submissao-palestras .event-infos li:before {
@@ -284,7 +284,7 @@ a {
 }
 
 .new-event:hover {
-	background-color: #fff; 
+	background-color: #fff;
 	color: #18BC9C;
 }
 
@@ -308,7 +308,7 @@ footer {
 footer p {
 	color: #fff;
 	text-align: center;
-	padding: 1em; 
+	padding: 1em;
 }
 
 /* SPECIFIC EVENTS */

--- a/main.css
+++ b/main.css
@@ -115,7 +115,7 @@ a {
 	flex: 0 0 auto;
 	height: 100%;
 	margin: 2em;
-	max-width: 15%;
+	width: 15%;
 	padding: 1em;
 }
 
@@ -124,7 +124,7 @@ a {
 }
 
 .event-media img {
-	max-width: 100%;
+	width: 100%;
 }
 
 .event .name {
@@ -192,7 +192,7 @@ a {
 	.event-media {
 		display: block;
 		text-align: center;
-		max-width: 40%;
+		width: 40%;
 	}
 }
 


### PR DESCRIPTION
# Grid desalinhado
Atualmente os eventos estão com os textos desalinhados na esquerda por possuírem logos de tamanhos diferentes.

## Changelog
Trocar de `max-width` por `width` já resolve a questão do grid a princípio, mas talvez fosse melhor criar algum tipo de container que define a largura antes do texto sem ter que fazer resize da imagem.


## *UPDATE:* após a modificação do `min-width`
### Atual: 
![image](https://cloud.githubusercontent.com/assets/2192462/23904109/7ad8f6a6-08a5-11e7-83a8-53de29d69e0a.png)

### Depois:
![image](https://cloud.githubusercontent.com/assets/2192462/23904134/9227dfde-08a5-11e7-99b9-2c70bac18fcf.png)
